### PR TITLE
Use randomized ID for file ID to avoid conflict

### DIFF
--- a/bin/setup.py
+++ b/bin/setup.py
@@ -28,7 +28,9 @@ def create_venv() -> None:
         return
     # Make sure venv is available
     try:
-        subprocess.run("python3.8 -m venv -h".split(), check=True, stdout=subprocess.PIPE)
+        subprocess.run(
+            "python3.8 -m venv -h".split(), check=True, stdout=subprocess.PIPE
+        )
     except subprocess.CalledProcessError:
         print(
             "Error: ensurepip is not available. "

--- a/src/downloader/youtube_dl_wrapper.py
+++ b/src/downloader/youtube_dl_wrapper.py
@@ -5,6 +5,7 @@ import logging
 from dataclasses import asdict
 from dataclasses import dataclass
 from typing import Any
+from uuid import uuid4
 
 import yt_dlp as youtube_dl
 
@@ -80,8 +81,10 @@ class DownloadResult:
 
 
 def download_youtube(url: str) -> DownloadResult | None:
+    unique_id = str(uuid4())
+
     options = {
-        "outtmpl": f"{tempdir.name}/%(id)s.%(ext)s",
+        "outtmpl": f"{tempdir.name}/{unique_id}.%(ext)s",
         "logger": YDLLogger(),
         "progress_hooks": [progress_hook],
     }
@@ -92,10 +95,8 @@ def download_youtube(url: str) -> DownloadResult | None:
         except youtube_dl.utils.DownloadError:
             return None
 
-        video_id = metadata["id"]
-        video_ext = metadata["ext"]
         return DownloadResult(
-            file_id=video_id,
-            file_path=f"{tempdir.name}/{video_id}.{video_ext}",
+            file_id=unique_id,
+            file_path=f"{tempdir.name}/{unique_id}.{metadata['ext']}",
             video_data=YoutubeVideoData.from_dict(**metadata),
         )

--- a/src/routes/youtube.py
+++ b/src/routes/youtube.py
@@ -46,7 +46,7 @@ def youtube() -> Response:
 
     return jsonify(
         {
-            "file_download_url": download_result.file_id,
+            "download_file_id": download_result.file_id,
             **download_result.video_data.to_dict(),
         }
     )


### PR DESCRIPTION
Currently, when a youtube video is downloaded, the file name is based on the video ID. This may be problematic in the future as 2 requests sent in are asking for the same youtube video but with different configs (resolution, output extension, etc). This commit aims to fix this by generating a random ID as the file name instead to avoid conflicts.
